### PR TITLE
TS-5709 marina enhancement. 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {murmur, ".*",
     {git, "https://github.com/lpgauth/murmur.git", {tag, "0.1.0"}}},
   {shackle, ".*",
-    {git, "git@github.com:tigertext/shackle.git", {branch, "0.6.2.1"}}}
+    {git, "git@github.com:tigertext/shackle.git", {branch, "master"}}}
 ]}.
 
 {edoc_opts, [
@@ -34,7 +34,6 @@
 {profiles, [
   {compile, [
     {erl_opts, [
-      warnings_as_errors,
       warn_export_all,
       warn_export_vars,
       warn_missing_spec,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,3 +1,4 @@
+{"1.1.0",
 [{<<"foil">>,
   {git,"https://github.com/lpgauth/foil.git",
        {ref,"56440106cc70f45d53ae461e98a547b5cde63646"}},
@@ -5,7 +6,7 @@
  {<<"granderl">>,{pkg,<<"granderl">>,<<"0.1.5">>},1},
  {<<"lz4">>,
   {git,"https://github.com/lpgauth/erlang-lz4.git",
-       {ref,"faf5c9e1bb083adb49638cddecfc9069596c43f9"}},
+       {ref,"90ed9b89419c26c1be60663c2eae7c3cfa0579a0"}},
   0},
  {<<"metal">>,{pkg,<<"metal">>,<<"0.1.1">>},1},
  {<<"murmur">>,
@@ -13,6 +14,11 @@
        {ref,"709445d213514ab1121fb67329dca945ffb11599"}},
   0},
  {<<"shackle">>,
-  {git,"https://github.com/tigertext/shackle.git",
-       {ref,"2f260ce11ae271774dbfef9818d4c11e07d37101"}},
-  0}].
+  {git,"git@github.com:tigertext/shackle.git",
+       {ref,"b8afc43398a5f67f28948562ee86e37a2df52ec4"}},
+  0}]}.
+[
+{pkg_hash,[
+ {<<"granderl">>, <<"F20077A68BD80B8D8783BD15A052813C6483771DEC1A5B837D307CBE92F14122">>},
+ {<<"metal">>, <<"5D3D1322DA7BCD34B94FED5486F577973685298883954F7A3E517EF5EF6953F5">>}]}
+].

--- a/rebar.lock
+++ b/rebar.lock
@@ -17,8 +17,4 @@
   {git,"git@github.com:tigertext/shackle.git",
        {ref,"b8afc43398a5f67f28948562ee86e37a2df52ec4"}},
   0}]}.
-[
-{pkg_hash,[
- {<<"granderl">>, <<"F20077A68BD80B8D8783BD15A052813C6483771DEC1A5B837D307CBE92F14122">>},
- {<<"metal">>, <<"5D3D1322DA7BCD34B94FED5486F577973685298883954F7A3E517EF5EF6953F5">>}]}
-].
+

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -82,8 +82,8 @@ stop(N) ->
     stop(N - 1).
 
 -spec node_down(atom(), non_neg_integer()) -> no_return().
-node_down(PoolName, _FailedWorkerCount) ->
-    shackle_utils:warning_msg(?MODULE, "cassandra connection pool down! ~p failed workers ~p", [PoolName]),
+node_down(PoolName, FailedWorkerCount) ->
+    shackle_utils:warning_msg(?MODULE, "cassandra connection pool down! ~p failed workers ~p", [PoolName, FailedWorkerCount]),
     ets:insert(?MODULE, {PoolName, true}).
 
 -spec node_up(atom(), non_neg_integer()) -> no_return().


### PR DESCRIPTION
fixed several problems: 
1. if there is a new cassandra node joined, marina should be able to automatically establish connection pools to that node. 
2. if there is a cassandra node removed from cassandra cluster, marina should be able to automatically remove the connection pool to that node. 
2. if a node is down, marina should not route any requests to that node. 

Requires PR https://github.com/tigertext/shackle/pull/2 
