### PR TITLE
return a term that is processable

### DIFF
--- a/src/marina_client.erl
+++ b/src/marina_client.erl
@@ -101,8 +101,8 @@ handle_data(Data, #state {
     {ok, Response :: term(), State :: term()} |
     {error,  Reason :: term(), State :: term()}.
 
-handle_timeout(_RequestId, State) ->
-    {ok, timeout, State}.
+handle_timeout(RequestId, State) ->
+    {ok, {RequestId, {error, timeout}}, State}.
 
 -spec terminate(state()) ->
     ok.


### PR DESCRIPTION
The value returned here gets processed by shackle_server_utils:process_responses/2 and when its not handled correctly it causes Shackle to crash, causing a cascading shutdown of Marina and all applications relying on these applications.