### PR TITLE
TS-6741 add a token bucket in marina to prevent hanging nodes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,6 +28,7 @@
 ]}.
 
 {erl_opts, [
+  {parse_transform, lager_transform},
   debug_info
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {coveralls_service_name, "travis-ci"}.
 
 {deps, [
-  lager, 
+  lager,
   {foil, ".*",
     {git, "https://github.com/lpgauth/foil.git", {tag, "0.1.1"}}},
   {lz4, ".*",

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,7 @@
 {coveralls_service_name, "travis-ci"}.
 
 {deps, [
+  lager, 
   {foil, ".*",
     {git, "https://github.com/lpgauth/foil.git", {tag, "0.1.1"}}},
   {lz4, ".*",
@@ -28,7 +29,6 @@
 ]}.
 
 {erl_opts, [
-  {parse_transform, lager_transform},
   debug_info
 ]}.
 

--- a/src/marina.erl
+++ b/src/marina.erl
@@ -93,11 +93,11 @@ async_reusable_query(Pool, Query, QueryOpts) ->
 
 call(Msg, QueryOpts) ->
     RoutingKey = marina_utils:query_opts(routing_key, QueryOpts),
-    %% select a node and accquire a ticket
+    %% select a node and acquire a ticket
     case marina_pool:node(RoutingKey) of
         {ok, Pool} ->
             Result = call(Pool, Msg, QueryOpts),
-            marina_bucket:return_ticket(Pool),
+            marina_bucket:return_ticket(Pool, Result),
             Result;
         {error, Reason} ->
             {error, Reason}

--- a/src/marina.erl
+++ b/src/marina.erl
@@ -93,9 +93,12 @@ async_reusable_query(Pool, Query, QueryOpts) ->
 
 call(Msg, QueryOpts) ->
     RoutingKey = marina_utils:query_opts(routing_key, QueryOpts),
+    %% select a node and accquire a ticket
     case marina_pool:node(RoutingKey) of
         {ok, Pool} ->
-            call(Pool, Msg, QueryOpts);
+            Result = call(Pool, Msg, QueryOpts),
+            marina_bucket:return_ticket(Pool),
+            Result;
         {error, Reason} ->
             {error, Reason}
     end.

--- a/src/marina_bucket.erl
+++ b/src/marina_bucket.erl
@@ -1,6 +1,6 @@
 -module(marina_bucket).
 -author("anders").
--compile([export_all]).
+-compile([{parse_transform, lager_transform}]).
 -behaviour(gen_server).
 
 %% API

--- a/src/marina_bucket.erl
+++ b/src/marina_bucket.erl
@@ -1,0 +1,145 @@
+-module(marina_bucket).
+-author("anders").
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/1, return_ticket/1, accquire_ticket/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+    code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-define(DEFAULT_TICKET, 10).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Spawns the server and registers the local name (unique)
+-spec(start_link(any()) ->
+    {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
+start_link(NodeId) ->
+    Name = to_name(NodeId),
+    gen_server:start_link({local, Name}, ?MODULE, [NodeId], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+%% @doc Initializes the server
+-spec(init(Args :: term()) ->
+    {ok, State :: #{}} | {ok, State :: #{}, timeout() | hibernate} |
+    {stop, Reason :: term()} | ignore).
+init([Name]) ->
+    {ok, #{ticket => ?DEFAULT_TICKET, name => Name, bucket => dict:new()}}.
+
+-spec return_ticket(atom()) -> ok.
+return_ticket(Pool) ->
+    Name = to_name(Pool),
+    gen_server:call(Name, return_ticket).
+
+-spec accquire_ticket(atom()) -> ok | error.
+accquire_ticket(Pool) ->
+    Name = to_name(Pool),
+    gen_server:call(Name, accquire_ticket).
+
+%% @private
+%% @doc Handling call messages
+-spec(handle_call(Request :: term(), From :: {pid(), Tag :: term()},
+    State :: #{}) ->
+    {reply, Reply :: term(), NewState :: #{}} |
+    {reply, Reply :: term(), NewState :: #{}, timeout() | hibernate} |
+    {noreply, NewState :: #{}} |
+    {noreply, NewState :: #{}, timeout() | hibernate} |
+    {stop, Reason :: term(), Reply :: term(), NewState :: #{}} |
+    {stop, Reason :: term(), NewState :: #{}}).
+handle_call(accquire_ticket, {From, _Ref}, State = #{ticket := T, name := Pool}) when T < 1 ->
+    shackle_utils:warning_msg(?MODULE, "cannot aacquire tickets!! pool ~p from ~p", [Pool, From]),
+    {reply, error, State};
+%% a pid accquire a ticket, give the ticket to the process and descrease the total number of etickets;
+handle_call(accquire_ticket, {From, _Ref}, State = #{name := Pool, ticket := Tickets, bucket := Dict}) ->
+    shackle_utils:warning_msg(?MODULE, "accquire ticket from pool ~p, current tickets: ~p", [Pool, Tickets]),
+    Dict1 =
+    case dict:find(From, Dict) of
+        error ->
+            dict:store(From, 1, Dict);
+        {ok, N} ->
+            dict:store(From, N+1, Dict)
+    end,
+    monitor(process, From),
+    {reply, ok, State#{ticket => (Tickets - 1), bucket => Dict1}};
+handle_call(return_ticket, {From, _Ref},  State = #{name := Pool, ticket := Tickets, bucket := Dict}) ->
+    shackle_utils:warning_msg(?MODULE, "release ticket from pool ~p, current tickets: ~p", [Pool, Tickets]),
+    {Dict1, TicketsToReturn} =
+        case dict:find(From, Dict) of
+            error ->
+                %% some process going to return a ticket but it is not recorded, there must be a leak
+                %% TODO: fix possible leak
+                {Dict, 0};
+            {ok, 1} ->
+                {dict:erase(From, Dict), 1};
+            {ok, N} when N>1->
+                {dict:store(From, N-1, Dict), 1}
+        end,
+    {reply, ok, State#{ticket => (Tickets + TicketsToReturn), bucket => Dict1}}.
+
+
+%% @private
+%% @doc Handling cast messages
+-spec(handle_cast(Request :: term(), State :: #{}) ->
+    {noreply, NewState :: #{}} |
+    {noreply, NewState :: #{}, timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: #{}}).
+handle_cast(_Request, State = #{}) ->
+    {noreply, State}.
+
+%% @private
+%% @doc Handling all non call/cast messages
+-spec(handle_info(Info :: timeout() | term(), State :: #{}) ->
+    {noreply, NewState :: #{}} |
+    {noreply, NewState :: #{}, timeout() | hibernate} |
+    {stop, Reason :: term(), NewState :: #{}}).
+handle_info({'DOWN', _MonitorRef, process, From, _Info}, State = #{name := Pool, ticket := Tickets, bucket := Dict}) ->
+    %% process down
+    shackle_utils:warning_msg(?MODULE, "release ticket from pool ~p, current tickets: ~p", [Pool, Tickets]),
+    {Dict1,  TicketsToReturn} =
+        case dict:find(From, Dict) of
+            error ->
+                %% all tickets for the process have been returned.
+                {Dict, 0};
+            {ok, N} ->
+                {dict:erase(From, Dict), N}
+        end,
+    {noreply, State#{ticket => (Tickets + TicketsToReturn), bucket => Dict1}};
+    
+handle_info(_Info, State = #{}) ->
+    {noreply, State}.
+
+%% @private
+%% @doc This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+-spec(terminate(Reason :: (normal | shutdown | {shutdown, term()} | term()),
+    State :: #{}) -> term()).
+terminate(_Reason, _State = #{}) ->
+    ok.
+
+%% @private
+%% @doc Convert process state when code is changed
+-spec(code_change(OldVsn :: term() | {down, term()}, State :: #{},
+    Extra :: term()) ->
+    {ok, NewState :: #{}} | {error, Reason :: term()}).
+code_change(_OldVsn, State = #{}, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+to_name(Pool) ->
+    list_to_atom(atom_to_list(Pool) ++ "__bucket").

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -120,7 +120,7 @@ check_node({ok, Node}, Strategy, _RoutingKey, N) ->
             %% remove routing key to fallback to random or token_aware without routing key.
             node(Strategy, undefined, N+1);
         false ->
-            case marina_bucket:accquire_ticket(Node) of
+            case marina_bucket:acquire_ticket(Node) of
                 error ->
                     shackle_utils:warning_msg(?MODULE, "failed to accquire ticket from work pool ~p, retrying", [Node]),
                     node(Strategy, undefined, N+1);

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -118,12 +118,12 @@ check_node({ok, Node}, Strategy, _RoutingKey, N) ->
             shackle_utils:warning_msg(?MODULE, "get a dead node when finding node, node id ~p, retrying", [Node]),
             %% the selected node is marked as down.
             %% remove routing key to fallback to random or token_aware without routing key.
-            node(Strategy, undefined, N+1);
+            node(Strategy, undefined, N + 1);
         false ->
             case marina_bucket:acquire_ticket(Node) of
                 error ->
                     shackle_utils:warning_msg(?MODULE, "failed to accquire ticket from work pool ~p, retrying", [Node]),
-                    node(Strategy, undefined, N+1);
+                    node(Strategy, undefined, N + 1);
                 ok ->
                     {ok, Node}
             end
@@ -178,10 +178,13 @@ start_node(<<A, B, C, D>> = RpcAddress) ->
         {pool_failure_callback_module, ?MODULE},
         {pool_recover_callback_module, ?MODULE}
     ],
-
+    PeerMaxTickets = ?GET_ENV(peer_max_tickets, 1000),
+    PeerTimeoutReduceFactor = ?GET_ENV(peer_timeout_reduce_factor, 2),
+    PeerStopPollingThreshold = ?GET_ENV(peer_stop_polling_threshold, 300),
+    
     case shackle_pool:start(NodeId, ?CLIENT, ClientOptions, PoolOptions) of
         ok ->
-            marina_bucket:start_link(NodeId),
+            marina_bucket:start_link(NodeId, PeerMaxTickets, PeerTimeoutReduceFactor, PeerStopPollingThreshold),
             {ok, NodeId};
         {error, Reason} ->
             {error, Reason}

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -216,7 +216,12 @@ stop_nodes(NodesToStop, Strategy, NewNodes) ->
         begin
             NodeId = node_id(RpcAddress),
             ets:delete(?MODULE, NodeId),
-            shackle_pool:stop(NodeId)
+            try
+                shackle_pool:stop(NodeId),
+                marina_bucket:stop(NodeId)
+            catch _:_ ->
+                ok
+            end
         end || {RpcAddress, _} <- NodesToStop
     ].
 

--- a/src/marina_pool_server.erl
+++ b/src/marina_pool_server.erl
@@ -103,7 +103,10 @@ handle_msg(?MSG_PEER_WATCHER, #state {
             {ok, State#state{
                 timer_ref = erlang:send_after(500, self(), ?MSG_PEER_WATCHER)
             }}
-    end.
+    end;
+%% ignore other messages
+handle_msg(_, State) ->
+    {ok, State}.
 
 
 -spec terminate(term(), state()) ->

--- a/src/marina_tester.erl
+++ b/src/marina_tester.erl
@@ -1,0 +1,62 @@
+-module(marina_tester).
+
+-export([test/2]).
+
+
+test(Speed, Rounds) ->
+    % F = fun() -> marina_bucket:acquire_ticket('marina_127.0.0.1'), marina_bucket:return_ticket('marina_127.0.0.1', {ok, normal}) end,
+    F = fun() -> marina:query(<<"select * from system.peers limit 1">>, #{}) end,
+    Result = fun() -> gather_results() end,
+    Pid = spawn(Result),
+    F1 = fun() -> {V, _} = timer:tc(F), Pid!V end,
+    send(F1, Speed, Rounds).
+
+send(_F, _, 0) ->
+    ok;
+send(F, Num, N) ->
+    Before = os:timestamp(),
+    [
+        begin
+            spawn(F)
+        end || _<- lists:seq(1, Num)],
+    After = os:timestamp(),
+    Diff = timer:now_diff(After, Before),
+    Sleep = (1000000 - Diff) div 1000,
+    timer:sleep(Sleep),
+    After1 = os:timestamp(),
+    Diff1 = timer:now_diff(After1, Before),
+    % ct:pal("time used ~p for reqeusts", [Diff1]),
+    send(F, Num, N-1).
+
+
+gather_results() ->
+    Before = os:timestamp(),
+    gather_results(Before, []).
+
+gather_results(StartTime, Result) ->
+    After = os:timestamp(),
+    Diff = timer:now_diff(After, StartTime),
+    case {Diff >= 1000000, Result}  of
+        {true, []} ->
+            ct:pal("gather_results stopped");
+        {true, _} ->
+            spawn(fun() -> result(Diff, Result) end),
+            Before = os:timestamp(),
+            gather_results(Before, []);
+        _ ->
+            receive
+                T ->
+                    gather_results(StartTime, [T|Result])
+            after 0 ->
+                gather_results(StartTime, Result)
+            end
+    end.
+
+result(_Diff, []) -> ok;
+result(Diff, Result) ->
+    Max = lists:max(Result),
+    Min = lists:min(Result),
+    Average = lists:sum(Result)/length(Result),
+    V = io_lib:format("~p\t~p\t~p\t~p\t~p\t", [Diff, Max, Min, Average, length(Result)]),
+    io:format("~s~n", [V]).
+


### PR DESCRIPTION
the performance of using gen_server and ets are similar: 
ets implementation https://github.com/tigertext/marina/pull/13 
![image](https://user-images.githubusercontent.com/3243828/79098511-b7c51600-7d94-11ea-80fb-09a6d963f18c.png)

Consider ETS is not atomic, better to use gen_server. 
[performance compare.xlsx](https://github.com/tigertext/marina/files/4468336/performance.compare.xlsx)
